### PR TITLE
Remove unused dependency on `http`

### DIFF
--- a/controllers/bugzillaController.js
+++ b/controllers/bugzillaController.js
@@ -2,7 +2,6 @@
 
 let Promise = require('promise'),
   _ = require('underscore'),
-  http = require("http"),
   https = require("https");
 
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "connect-redis": "~1.4.6",
     "express": "~3.4.7",
     "express-persona": "~0.1.1",
-    "http": "0.0.0",
     "i18n-2": "^0.4.6",
     "jade": "~0.35.0",
     "json": "0.0.14",


### PR DESCRIPTION
The `http` node package issues a warning when doing `npm install` and appears to be unused. This patch removes it.
