### PR TITLE
Reorder initial operations to fix first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Setting up this project
 7. Install node.js (Current Version: v0.10.20)
 8. Run: ```npm install``` in the source code directory
 9. Run: ```node --harmony app```
-10. Once the server is running visit ```localhost:22935/initData```
-11. Browser to ```localhost:22935/videos``` to see all of the data or ```localhost:22935/slug``` to see a specific video
+11. Browse to ```localhost:22935``` to see all of the data
 
 Exercise module
 ===============
@@ -29,6 +28,11 @@ Running tests
 Tests are run using the Mocha framework. To get tests working just run:
 
 ```npm test```
+
+Reinitializing data
+===================
+
+Once the server is running, you can init data from videos.json by visiting ```localhost:22935/initData```.
 
 Setting up redis on Windows
 ===========================

--- a/controllers/appController.js
+++ b/controllers/appController.js
@@ -12,9 +12,9 @@ exports.init = function(callback) {
   configController.initPromise().then(function() {
     return redisController.initPromise(configController.config.redisPort);
   }).then(function() {
-    return tagsController.initPromise();
-  }).then(function() {
     return lessonController.initPromise();
+  }).then(function() {
+    return tagsController.initPromise();
   }).then(function() {
     return rssController.initPromise(lessonController.categories);
   }).then(function() {


### PR DESCRIPTION
The order in `initData` is a bit off, so I changed it:
1. tagsController loads tags from redis to JS
2. lessonController loads tags from videos.json into redis (but that's too late).

(I do not explain why this was not an issue on an ArchLinux machine but was an issue on an Ubuntu machine.)

Also, the docs say "init data by visiting `localhost:22935/initData`" but init data is already called when launching `node --harmony app`. If calling `initData` when the server is already running is not useful, I can remove the documentation about it and remove the route.
